### PR TITLE
Rng function as optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ npm install sphere-random
 
 # API
 
-#### `require('sphere-random')(d)`
+#### `require('sphere-random')(d, rng)`
 Generates a random point on the surface of a d-dimensional hypersphere
 
 * `d` is the dimension of the sphere to sample
+* `rng` is the optional random number generator function (defaults to Math.random)
 
 **Returns** A point on the surface of a d-dimensional sphere
 

--- a/rand-sphere.js
+++ b/rand-sphere.js
@@ -2,21 +2,24 @@
 
 module.exports = sampleSphere
 
-function sampleSphere(d) {
+var defaultRng = Math.random
+
+function sampleSphere(d, rng) {
+  rng = rng || defaultRng
   var v = new Array(d)
   var d2 = Math.floor(d/2)<<1
   var r2 = 0.0
   for(var i=0; i<d2; i+=2) {
-    var rr = -2.0 * Math.log(Math.random())
+    var rr = -2.0 * Math.log(rng())
     var r =  Math.sqrt(rr)
-    var theta = 2.0 * Math.PI * Math.random()
+    var theta = 2.0 * Math.PI * rng()
     r2 += rr
     v[i] = r * Math.cos(theta)
     v[i+1] = r * Math.sin(theta)
   }
   if(d % 2) {
-    var x = Math.sqrt(-2.0 * Math.log(Math.random())) * 
-            Math.cos(2.0 * Math.PI * Math.random())
+    var x = Math.sqrt(-2.0 * Math.log(rng())) *
+            Math.cos(2.0 * Math.PI * rng())
     v[d-1] = x
     r2 += Math.pow(x, 2)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -18,3 +18,14 @@ tape('sample-sphere', function(t) {
 
   t.end()
 })
+
+tape('sample-sphere, passing rng as argument', function(t) {
+    var riggedRng = function () { return 0.5; }
+
+    var p = sampleSphere(2, riggedRng)
+
+    t.equals(p[0], -1)
+    t.equals(p[1], 1.2246063538223773e-16)
+
+    t.end();
+})


### PR DESCRIPTION
This PR adds a second operator to pass a custom random number generator function.

This is particularly useful when we want reproducible results using a seedable RNG.
